### PR TITLE
Prevent multiple selectize/dynamic color brushes from being rendered …

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## BUG FIXES
 
+* Duplicate `highlight(selectize=T)` dropdowns are no longer rendered in Shiny (#1936).
 * `group_by.plotly()` now properly retains crosstalk information across `{dplyr}` versions (#1920).
 * Fixes some issues with `name` and `frames` when both attributes are specified. (#1903 and #1618).
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -379,7 +379,7 @@ supply_highlight_attrs <- function(p) {
 
     # include one selectize dropdown per "valid" SharedData layer
     if (isTRUE(p$x$highlight$selectize)) {
-      p$x$selectize[[new_id()]] <- list(
+      p$x$selectize[[i]] <- list(
         items = data.frame(value = k, label = k), group = i
       )
     }

--- a/inst/htmlwidgets/plotly.js
+++ b/inst/htmlwidgets/plotly.js
@@ -74,7 +74,7 @@ HTMLWidgets.widget({
     });
       
       // inject a "control panel" holding selectize/dynamic color widget(s)
-    if (x.selectize || x.highlight.dynamic && !instance.plotly) {
+    if ((x.selectize || x.highlight.dynamic) && !instance.plotly) {
       var flex = document.createElement("div");
       flex.class = "plotly-crosstalk-control-panel";
       flex.style = "display: flex; flex-wrap: wrap";


### PR DESCRIPTION
…in shiny (#1936)

* Close #1584: Prevent multiple selectize/dynamic color brushes from being rendered in shiny

* Update news